### PR TITLE
chore: use latest ecmaVersion

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,6 @@ export default [
   { ignores: ["dist/", "*.config.js"] },
   {
     languageOptions: {
-      ecmaVersion: 6,
       sourceType: "module",
       globals: {
         ...globals.browser,


### PR DESCRIPTION
This fixes the error: `Parsing error: Unexpected token function eslint`